### PR TITLE
Add firmware version IML74K-ZSLPG for galaxy-s2

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -29,6 +29,8 @@ case "$DEVICE_BUILD_ID" in
   FIRMWARE=XXLPQ ;;
 "IML74K.ZSLPF")
   FIRMWARE=ZSLPF ;;
+"IML74K.ZSLPG")
+  FIRMWARE=ZSLPG ;;
 *)
   echo Your device has unknown firmware $DEVICE_BUILD_ID >&2
   exit 1 ;;


### PR DESCRIPTION
Add a firmware version IML74K-ZSLPG in extract-files.sh to support galaxy-s2
