### PR TITLE
B2G-issues-18: add libril.so to the list of files extracted.

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -178,6 +178,7 @@ COMMON_LIBS="
 	libhdmi.so
 	libhdmiclient.so
 	libTVOut.so
+	libril.so
 	libsecril-client.so
 	libsec-ril.so
 	libMali.so


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=757852. 
